### PR TITLE
Update PSGallery script

### DIFF
--- a/AutomationAccountManagement/Import-ModuleFromPSGalleryToAutomation.ps1
+++ b/AutomationAccountManagement/Import-ModuleFromPSGalleryToAutomation.ps1
@@ -96,7 +96,7 @@ function _doImport {
     $Url = "https://www.powershellgallery.com/api/v2/Search()?`$filter=IsLatestVersion&searchTerm=%27$ModuleName%27&targetFramework=%27%27&includePrerelease=false&`$skip=0&`$top=40" 
     $SearchResult = Invoke-RestMethod -Method Get -Uri $Url -UseBasicParsing
 
-    if($SearchResult.Length -and $SearchResult.Length -gt 1) {
+    if($SearchResult -ne $null) {
         $SearchResult = $SearchResult | Where-Object -FilterScript {
             return $_.properties.title -eq $ModuleName
         }

--- a/AutomationAccountManagement/Import-ModuleFromPSGalleryToAutomation.ps1
+++ b/AutomationAccountManagement/Import-ModuleFromPSGalleryToAutomation.ps1
@@ -122,13 +122,13 @@ function _doImport {
         if($Dependencies -and $Dependencies.Length -gt 0) {
             $Dependencies = $Dependencies.Split("|")
 
-            # parse depencencies, which are in the format: module1name:module1version:|module2name:module2version:
+            # parse depencencies, which are in the format: module1name:[module1version]:|module2name:[module2version]:
             $Dependencies | ForEach-Object {
 
                 if($_ -and $_.Length -gt 0) {
                     $Parts = $_.Split(":")
                     $DependencyName = $Parts[0]
-                    $DependencyVersion = $Parts[1]
+                    $DependencyVersion = $Parts[1] -replace '[\[,\]]',""
 
                     # check if we already imported this dependency module during execution of this script
                     if(!$ModulesImported.Contains($DependencyName)) {


### PR DESCRIPTION
Looks like the PSGallery responses have changed and so `Import-ModuleFromPSGalleryToAutomation` was no longer functioning. These changes work in my testing at least:

* Dependencies are now formatted with brackets around the version, e.g. `AzureRM.Profile:[2.2.0]:`, so it was trying to hit `VERBOSE: GET https://www.powershellgallery.com/api/v2/package/AzureRM.profile/[2.2.0] with 0-byte payload`

* `Invoke-RestMethod`'s output here:
```powershell
    $Url = "https://www.powershellgallery.com/api/v2/Search()?`$filter=IsLatestVersion&searchTerm=%27$ModuleName%27&targetFramework=%27%27&includePrerelease=false&`$skip=0&`$top=40" 
    $SearchResult = Invoke-RestMethod -Method Get -Uri $Url -UseBasicParsing
```
is a `System.Xml.XmlElement#http://www.w3.org/2005/Atom#entry` object (since PSGallery is responding with `application/atom+xml`)and doesn't have a `Length` member. It seems like the script was just checking to make sure the response wasn't null so I changed the check to that.