### PR TITLE
Updated Find-AzureRmResource cmdlet with Get-AzureRmResource cmdlet

### DIFF
--- a/Utility/ARM/Update-ModulesInAutomationToLatestVersion.ps1
+++ b/Utility/ARM/Update-ModulesInAutomationToLatestVersion.ps1
@@ -218,7 +218,7 @@ try {
        {
                 throw "This is not running from the automation service. Please specify ResourceGroupName and AutomationAccountName as parameters"
        }
-       $AutomationResource = Find-AzureRmResource -ResourceType Microsoft.Automation/AutomationAccounts
+       $AutomationResource = Get-AzureRmResource -ResourceType Microsoft.Automation/AutomationAccounts
 
         foreach ($Automation in $AutomationResource)
         {


### PR DESCRIPTION
Since Find-AzureRmResource is now removed, Updated the runbook to use Get-AzureRmResource instead.