### PR TITLE
Typo in line 231

### DIFF
--- a/Utility/ARM/New-OnPremiseHybridWorker.ps1
+++ b/Utility/ARM/New-OnPremiseHybridWorker.ps1
@@ -228,7 +228,7 @@ $null = Set-AzureRmContext -SubscriptionID $SubscriptionID
 
 # Check that the resource groups are valid
 $null = Get-AzureRmResourceGroup -Name $AAResourceGroupName
-if ($OMSResouceGroupName) {
+if ($OMSResourceGroupName) {
     $null = Get-AzureRmResourceGroup -Name $OMSResourceGroupName
 } else {
     $OMSResourceGroupName = $AAResourceGroupName


### PR DESCRIPTION
Due to a typo in line 231 (missing 'r') the script fails, if $AAResourceGroupName is unequal to $OMSResourceGroupName.