### PR TITLE
Fix: typo in $OMSResourceGroupName

### DIFF
--- a/Utility/ARM/New-OnPremiseHybridWorker.ps1
+++ b/Utility/ARM/New-OnPremiseHybridWorker.ps1
@@ -228,7 +228,7 @@ $null = Set-AzureRmContext -SubscriptionID $SubscriptionID
 
 # Check that the resource groups are valid
 $null = Get-AzureRmResourceGroup -Name $AAResourceGroupName
-if ($OMSResouceGroupName) {
+if ($OMSResourceGroupName) {
     $null = Get-AzureRmResourceGroup -Name $OMSResourceGroupName
 } else {
     $OMSResourceGroupName = $AAResourceGroupName


### PR DESCRIPTION
Typo causing error in forcing script to try looking for OMS in wrong resource group.