### PR TITLE
Update-SQLIndexRunbook.ps1 Addressing table in other schemas

### DIFF
--- a/Utility/SQL/Update-SQLIndexRunbook.ps1
+++ b/Utility/SQL/Update-SQLIndexRunbook.ps1
@@ -155,9 +155,10 @@ workflow Update-SQLIndexRunbook
 "@
         # Return the tables with their corresponding average fragmentation
         $Cmd=new-object system.Data.SqlClient.SqlCommand($SQLCommandString, $Conn)
-        $Cmd.CommandTimeout=120
+        $Cmd.CommandTimeout=600
         
         # Execute the SQL command
+        Write-Verbose ("Fetching Fragmented Table Stats...")
         $FragmentedTable=New-Object system.Data.DataSet
         $Da=New-Object system.Data.SqlClient.SqlDataAdapter($Cmd)
         [void]$Da.fill($FragmentedTable)
@@ -165,7 +166,7 @@ workflow Update-SQLIndexRunbook
  
         # Get the list of tables with their object ids
         $SQLCommandString = @"
-        SELECT  t.name AS TableName, t.OBJECT_ID FROM sys.tables t
+        SELECT  '[' + s.name + '].[' + t.name + ']' AS TableName, t.OBJECT_ID FROM sys.tables t inner join sys.schemas s on t.schema_id = s.schema_id
 "@
 
         $Cmd=new-object system.Data.SqlClient.SqlCommand($SQLCommandString, $Conn)


### PR DESCRIPTION
Updates for Update-SQLIndexRunbook.ps1
-Increased the the timeout for the execution of the average fragmentation query. We've found that having multiple severely fragmented tables leads to the timeout being reached. 
-Add another Write-Verbose statement to give feed back on where the script is in it's execution. 
-Concatenate the schema with the table name so that the script can handle tables with the same name in different schemas.