### PR TITLE
Wrong string filtering

### DIFF
--- a/Utility/ARM/Update-ModulesInAutomationToLatestVersion.ps1
+++ b/Utility/ARM/Update-ModulesInAutomationToLatestVersion.ps1
@@ -131,7 +131,7 @@ function _doImport {
                 if($_ -and $_.Length -gt 0) {
                     $Parts = $_.Split(":")
                     $DependencyName = $Parts[0]
-                    $DependencyVersion = ($Parts[1] -replace '\[', '') -replace '\]', ''
+                    $DependencyVersion = $Parts[1] -replace '[^0-9.]'
 
                     # check if we already imported this dependency module during execution of this script
                     if(!$ModulesImported.Contains($DependencyName)) {


### PR DESCRIPTION
 Wrong string filtering causing dependency module version invalid.
For example, AzureRm.Automation has $PackageDetails.entry.properties.Dependencies as AzureRM.Profile:[5.5.1, ):.
The original $DependencyVersion will become "5.5.1, )" in this case.
Just replace any characters that are not dot or numbers will work.