### PR TITLE
Update Start-AzureV2VMs.ps1

### DIFF
--- a/Utility/ARM/Start-AzureV2VMs.ps1
+++ b/Utility/ARM/Start-AzureV2VMs.ps1
@@ -105,7 +105,7 @@ else {
 foreach ($VM in $VMs) {
 	$StartRtn = $VM | Start-AzureRmVM -ErrorAction Continue
 
-	if (!$StartRtn.IsSuccessStatusCode) {
+	if ($StartRtn.Status -ne "Succeeded") {
 		# The VM failed to start, so send notice
         Write-Output ($VM.Name + " failed to start")
         Write-Error ($VM.Name + " failed to start. Error was:") -ErrorAction Continue


### PR DESCRIPTION
Fixed wrong property in the return object (https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.commands.compute.models.pscomputelongrunningoperation?view=azurerm-ps) of Start-AzureRmVM.
More details on my blog post: https://www.thomas-zuehlke.de/2019/03/start-stop-of-azure-vms-with-automation/