### PR TITLE
Updated New-OnPremiseHybridWorker.ps1. Check presence of Az module to…

### DIFF
--- a/Utility/ARM/New-OnPremiseHybridWorker.ps1
+++ b/Utility/ARM/New-OnPremiseHybridWorker.ps1
@@ -208,11 +208,17 @@ foreach ($Module in $Modules) {
     $CurrentModule = Get-Module -Name $ModuleName -ListAvailable | where "Version" -eq $ModuleVersion
 
     if (!$CurrentModule) {
+    
+        if (($ModuleName -eq "AzureRm") -and (Get-InstalledModule -Name Az)) {
+            Write-Output "$ModuleName was not found but Az module is installed instead. Enabling ARM Aliases.."
+            Enable-AzureRmAlias
+        } else {
 
-        $null = Install-Module -Name $ModuleName -RequiredVersion $ModuleVersion -Force
-        Write-Output "     Successfully installed version $ModuleVersion of $ModuleName..."
-
-    } else {
+            $null = Install-Module -Name $ModuleName -RequiredVersion $ModuleVersion -Force
+            Write-Output "     Successfully installed version $ModuleVersion of $ModuleName..."
+        }
+    }
+    else {
         Write-Output "     Required version $ModuleVersion of $ModuleName is installed..."
     }
 }


### PR DESCRIPTION
… skip ARM module installation.

When you have Az module installed, this scripts downloads the AzureRM module and after that it fails.
It doesn't make sense as Az module is the newer one and the AzureRM hasn't been updated for 6 months