### PR TITLE
make pypi html parser regex less greedy

### DIFF
--- a/Utility/Python/import_py3package_from_pypi.py
+++ b/Utility/Python/import_py3package_from_pypi.py
@@ -66,7 +66,7 @@ def get_packagename_from_filename(packagefilename):
 
 def resolve_download_url(packagename, packagefilename):
     response = requests.get("%s/%s" % (PYPI_ENDPOINT, packagename))
-    download_uri_regex = "<a href=\"([^\"]+)\".*>%s<" % packagefilename
+    download_uri_regex = "<a href=\"([^\"]+)\"[^>]*?>%s<" % packagefilename
     download_uri_match = re.search(download_uri_regex, str(response.content))
     print ("Detected download uri %s for %s" % (download_uri_match.group(1), packagename))
     return download_uri_match.group(1)


### PR DESCRIPTION
This makes the regex to find the download link of a python package less greedy.

Before, on this string :

```
<a href="https://files.pythonhosted.org/packages/ba/bb/dfa0141a32d773c47e4dede1a617c59a23b74dd302e449cf85413fc96bc4/requests-0.2.0.tar.gz#sha256=813202ace4d9301a3c00740c700e012fb9f3f8c73ddcfe02ab558a8df6f175fd">requests-0.2.0.tar.gz</a><br/>
<a href="https://files.pythonhosted.org/packages/4b/ad/d536b2e572e843fda13e4458c67f937b05ce359722c1e4cdad35ba05b6e3/requests-0.2.1.tar.gz#sha256=d54eb33499f018fc6bd297613bf866f8d134629c8e02964aab6ef951f460e41e">requests-0.2.1.tar.gz</a><br/>
```

for the package `requests-0.2.1.tar.gz` it would have matched the download link of package `requests-0.2.0.tar.gz` which is not intended behavior (in fact it always download the first link found in the page)

