### PR TITLE
Update import py3 package runbook to support nested dependencies

### DIFF
--- a/Utility/Python/import_py3package_from_pypi.py
+++ b/Utility/Python/import_py3package_from_pypi.py
@@ -8,14 +8,17 @@ Args:
     resource_group (-g) - Resource group name of the Automation account
     automation_account (-a) - Automation account name
     module_name (-m) - Name of module to import from pypi.org
+    version (-v) - Version of module to be imported.
     Imports module
     Example:
-        import_python3package_from_pypi.py -s xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx -g contosogroup -a contosoaccount -m pytz
+        import_python3package_from_pypi.py -s xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx -g contosogroup -a contosoaccount -m pytz -v 1.0.0
 Changelog:
     2020-12-29 AutomationTeam:
     -Import Python 3 package with dependencies
 """
 import requests
+import subprocess
+import json
 import sys
 import pip
 import os
@@ -24,95 +27,91 @@ import shutil
 import json
 import time
 import getopt
+import re
+from pkg_resources import packaging
 
 #region Constants
 PYPI_ENDPOINT = "https://pypi.org/simple"
 FILENAME_PATTERN = "[\\w]+"
 #endregion
 
-def get_automation_runas_token():
-    """ Returns a token that can be used to authenticate against Azure resources """
-    from OpenSSL import crypto
-    import adal
-    import automationassets
+def extract_and_compare_version(url, min_req_version):
+    try:
+        re.search('\d+(\.\d+)+', url).group(0)        
+    except :
+         print ("Failed to extract and compare version URL  %s min_req_versionor %s" % (url, min_req_version))
 
-    # Get the Azure Automation RunAs service principal certificate
-    cert = automationassets.get_automation_certificate("AzureRunAsCertificate")
-    sp_cert = crypto.load_pkcs12(cert)
-    pem_pkey = crypto.dump_privatekey(crypto.FILETYPE_PEM, sp_cert.get_privatekey())
+    extracted_ver = re.search('\d+(\.\d+)+', url).group(0)
+    print ("Extracted version   %s min_req_versionor %s" % (extracted_ver, min_req_version))
+    return packaging.version.parse(extracted_ver) >= packaging.version.parse(min_req_version)  
+    
 
-    # Get run as connection information for the Azure Automation service principal
-    runas_connection = automationassets.get_automation_connection("AzureRunAsConnection")
-    application_id = runas_connection["ApplicationId"]
-    thumbprint = runas_connection["CertificateThumbprint"]
-    tenant_id = runas_connection["TenantId"]
-
-    # Authenticate with service principal certificate
-    resource = "https://management.core.windows.net/"
-    authority_url = ("https://login.microsoftonline.com/" + tenant_id)
-    context = adal.AuthenticationContext(authority_url)
-    azure_credential = context.acquire_token_with_client_certificate(
-        resource,
-        application_id,
-        pem_pkey,
-        thumbprint)
-
-    # Return the token
-    return azure_credential.get('accessToken')
-
-def get_packagename_from_filename(packagefilename):
-    match = re.match(FILENAME_PATTERN, packagefilename)
-    return match.group(0)
-
-def resolve_download_url(packagename, packagefilename):
+def resolve_download_url(packagename, version):
     response = requests.get("%s/%s" % (PYPI_ENDPOINT, packagename))
-    urls = re.findall(r'href=[\'"]?([^\'" >]+)', str(response.content))   
+    urls = re.findall(r'href=[\'"]?([^\'" >]+)', str(response.content))
     for url in urls:
-        if packagefilename in url:
+        if 'cp38-win_amd64.whl' in url and version in url:
             print ("Detected download uri %s for %s" % (url, packagename))
             return(url)
+    for url in urls:
+        if 'py3-none-any.whl' in url and version in url:
+            print ("Detected download uri %s for %s" % (url, packagename))
+            return(url)
+    for url in urls:
+        if 'abi3-win_amd64.whl' in url and 'cp36' in url and version in url:
+            print ("Detected download uri %s for %s" % (url, packagename))
+            return(url)        
+    for url in urls:
+        if 'cp38-win_amd64.whl' in url and extract_and_compare_version(url,version):
+            print ("Detected download uri %s for %s" % (url, packagename))
+            return(url)            
+    for url in urls:
+        if 'py3-none-any.whl' in url and extract_and_compare_version(url,version):
+            print ("Detected download uri %s for %s" % (url, packagename))
+            return(url)  
+    print("Could not find WHL from PIPI for package %s and version %s" % (packagename, version))        
 
 def send_webservice_import_module_request(packagename, download_uri_for_file):
     request_url = "https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Automation/automationAccounts/%s/python3Packages/%s?api-version=2018-06-30" \
                   % (subscription_id, resource_group, automation_account, packagename)
 
     requestbody = { 'properties': { 'description': 'uploaded via automation', 'contentLink': {'uri': "%s" % download_uri_for_file} } }
-    headers = {'Content-Type' : 'application/json', 'Authorization' : "Bearer %s" % token}
+    headers = {'Content-Type' : 'application/json', 'Authorization' : 'Bearer %s' % token}
     r = requests.put(request_url, data=json.dumps(requestbody), headers=headers)
-    print ("Request status for package %s was %s" % (packagename, str(r.status_code)))
     if str(r.status_code) not in ["200", "201"]:
         raise Exception("Error importing package {0} into Automation account. Error code is {1}".format(packagename, str(r.status_code)))
 
-def make_temp_dir():
-    destdir = os.path._getfullpathname("tempDownloadDir")
-    if os.path.exists(destdir):
-        shutil.rmtree(destdir)
-    os.makedirs(destdir, 0o755)
-    return destdir
+def find_and_dependencies(packagename, version, dep_graph, dep_map):
+    dep_map.update({packagename: version})
+    for child in dep_graph:
+        if child['package']['key'].casefold() == packagename.casefold():
+            for dep in child['dependencies']:
+                version = dep['installed_version'] 
+                if version == '?' :
+                    version = dep['required_version'][2:]
+                    if "!" in version :
+                        version = version .split('!')[0]
+                find_and_dependencies(dep['package_name'],version,dep_graph, dep_map)  
+                
 
-def import_package_with_dependencies (packagename):
-    # download package with all depeendencies
-    download_dir = make_temp_dir()
-    pip.main(['download', '-d', download_dir, packagename])
-    for file in os.listdir(download_dir):
-        pkgname = get_packagename_from_filename(file)
-        download_uri_for_file = resolve_download_url(pkgname, file)
-        send_webservice_import_module_request(pkgname, download_uri_for_file)
-        # Sleep a few seconds so we don't send too many import requests https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#automation-limits
-        time.sleep(10)
+subprocess.check_call([sys.executable, '-m', 'pip', 'install','pipdeptree'])
+
+subprocess.check_call([sys.executable, '-m', 'pip', 'install','packaging'])
+
 
 if __name__ == '__main__':
     if len(sys.argv) < 9:
         raise Exception("Requires Subscription id -s, Automation resource group name -g, account name -a, and module name -g as arguments. \
-                        Example: -s xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx -g contosogroup -a contosoaccount -m pytz ")
+                        Example: -s xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx -g contosogroup -a contosoaccount -m pytz -v version")
 
     # Process any arguments sent in
     subscription_id = None
     resource_group = None
     automation_account = None
     module_name = None
+    version_name = None
 
-    opts, args = getopt.getopt(sys.argv[1:], "s:g:a:m:")
+    opts, args = getopt.getopt(sys.argv[1:], "s:g:a:m:v:")
     for o, i in opts:
         if o == '-s':  
             subscription_id = i
@@ -122,10 +121,25 @@ if __name__ == '__main__':
             automation_account = i
         elif o == '-m': 
             module_name = i
+        elif o == '-v':
+            version_name = i    
 
-    # Set Run as token for this automation accounts service principal to be used to import the package into Automation account
-    token = get_automation_runas_token()
+    module_with_version = module_name + "==" + version_name
+    # Install the given module first
+    for i in (1,10):
+        try:
+            subprocess.check_call([sys.executable, '-m', 'pip', 'install', module_with_version])
+            break
+        except subprocess.CalledProcessError as e:
+            continue 
 
+    result = subprocess.run(
+        [sys.executable, "-m", "pipdeptree","-j"], capture_output=True, text=True
+    )
+    dep_graph = json.loads(result.stdout)
+    dep_map = {}
+    find_and_dependencies(module_name,version_name,dep_graph,dep_map)
     # Import package with dependencies from pypi.org
-    import_package_with_dependencies(module_name)
-    print ("\nCheck the python 3 packages page for import status...")
+    for module_name,version in dep_map.items():
+        download_uri_for_file = resolve_download_url(module_name, version)
+


### PR DESCRIPTION
Currently import py3 package runbook do not support nested dependencies resolution.

I have Updated the Script to import python3 Modules along with the Dependencies. The script uses pipdeptree  to determine dependences and import them one by one. 
 
Few of packages which I have tried importing with dependencies are :-
1.	Pyodbc
2.	Msrestazure
3.	Asteroids
4.	Inda
5.	Insight 

![image](https://user-images.githubusercontent.com/25101734/216526824-6a814cd3-4c24-4a7d-a02a-630273bd35cd.png)